### PR TITLE
Adds a delta to expiry times for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ func main() {
 	}
 }
 ```
+
+## Maintainers
+- [Taylor Thomas](https://github.com/thomastaylor312)
+- [Roger Ignazio](https://github.com/rji)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -24,10 +24,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/Nike-Inc/cerberus-go-client/api"
 	"github.com/Nike-Inc/cerberus-go-client/utils"
 )
+
+// expiryDelta is the amount of time to subtract from the expiry time to compensate for
+// network request time and clock skew
+const expiryDelta time.Duration = 60 * time.Second
 
 // The Auth interface describes the methods that all authentication providers must satisfy
 type Auth interface {

--- a/auth/aws.go
+++ b/auth/aws.go
@@ -144,7 +144,7 @@ func (a *AWSAuth) Refresh() error {
 		return err
 	}
 	a.token = r.Data.ClientToken.ClientToken
-	a.expiry = time.Now().Add(time.Duration(r.Data.ClientToken.Duration) * time.Second)
+	a.expiry = time.Now().Add((time.Duration(r.Data.ClientToken.Duration) * time.Second) - expiryDelta)
 	a.headers.Set("X-Vault-Token", r.Data.ClientToken.ClientToken)
 	return nil
 }

--- a/auth/aws_test.go
+++ b/auth/aws_test.go
@@ -111,6 +111,9 @@ func TestGetTokenAWS(t *testing.T) {
 			Convey("And should have a valid token", func() {
 				So(tok, ShouldEqual, "a-cool-token")
 			})
+			Convey("And should have a valid expiry time", func() {
+				So(a.expiry, ShouldHappenOnOrBefore, time.Now().Add(1*time.Hour))
+			})
 		})
 	}))
 	Convey("A valid AWSAuth", t, func() {

--- a/auth/user.go
+++ b/auth/user.go
@@ -222,5 +222,5 @@ func (u *UserAuth) setToken(token string, duration int) {
 	u.token = token
 	// Set the auth header up to make things easier
 	u.headers.Set("X-Vault-Token", token)
-	u.expiry = time.Now().Add(time.Duration(duration) * time.Second)
+	u.expiry = time.Now().Add((time.Duration(duration) * time.Second) - expiryDelta)
 }

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -168,7 +168,7 @@ func TestGetTokenUser(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(t, ShouldEqual, token)
 			Convey("And should have a valid expiry time", func() {
-				So(c.expiry, ShouldHappenOnOrBefore, time.Now().Add(3600*time.Second))
+				So(c.expiry, ShouldHappenOnOrBefore, time.Now().Add(1*time.Hour))
 			})
 			Convey("X-Vault-Token header should be set", func() {
 				So(c.headers.Get("X-Vault-Token"), ShouldEqual, token)


### PR DESCRIPTION
An expiry delta time was needed to avoid problems with clock skew.
This also adds a missing unit test.

Closes #2